### PR TITLE
Revert "Bump core-js from 2.6.5 to 3.3.6"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "electron-context-menu": "0.15.0",
     "electron-updater": "4.1.2",
     "element-ui": "2.12.0",
-    "core-js": "3.3.6",
+    "core-js": "2.6.5",
     "vue": "2.6.10",
     "vue-router": "3.1.2"
   },


### PR DESCRIPTION
Reverts gengjiawen/electron-devdocs#58